### PR TITLE
Couple of tweaks around sessions for Express 4

### DIFF
--- a/lib/connect-elasticsearch.js
+++ b/lib/connect-elasticsearch.js
@@ -24,8 +24,8 @@ var elasticsearch = require('elasticsearch'),
     _ttl = '1h';
 
 
-module.exports = function(connect) {
-  var Store = connect.session.Store;
+module.exports = function(session) {
+  var Store = session.Store;
 
   function ElasticsearchStore(options) {
     var self = this;
@@ -61,10 +61,10 @@ module.exports = function(connect) {
   }
   
 
-  util.inherits(ElasticsearchStore, connect.session.Store);
+  util.inherits(ElasticsearchStore, session.Store);
 
   ElasticsearchStore.prototype.pSid = function(sid) {
-    return this.options.prefix + sid;
+    return (this.options.prefix || '') + sid;
   }
 
   ElasticsearchStore.prototype.get = function(sid, cb) {


### PR DESCRIPTION
I just pass in the raw session instead of passing in the connect object to reference the session since Express 4 changed that stuff up.

I also made sure the session prefix doesn't prepend "undefined".
