### PR TITLE
Fix example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 ```javascript
 
     var express = require('express');
-    var ElasticsearchStore = require('connect-elasticsearch')(express);
+    var session = require('express-session');
+    var ElasticsearchStore = require('connect-elasticsearch')(session);
 
     var app = express();
 


### PR DESCRIPTION
Express 4 uses `express-session` so I changed the example code.
